### PR TITLE
:bug: fix warning, run uv in tox

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,4 +3,4 @@
 set -x
 
 export PYTHONPATH=.
-uv run pytest -vv --cov=pipenv_uv_migrate --cov-report=term ${@} tests
+uv run --active pytest -vv --cov=pipenv_uv_migrate --cov-report=term ${@} tests


### PR DESCRIPTION
fix "warning: `VIRTUAL_ENV=.tox/py` does not match the project environment path `.venv` and will be ignored"