### PR TITLE
Fix migration when multiple source exist, including pypi 

### DIFF
--- a/pipenv_uv_migrate/migration.py
+++ b/pipenv_uv_migrate/migration.py
@@ -5,6 +5,7 @@ import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from packaging.markers import Marker
 from packaging.requirements import Requirement
@@ -13,6 +14,9 @@ from tomlkit import aot, array, dumps, inline_table, key, table
 from typing_extensions import Any
 
 from pipenv_uv_migrate.loader import load_pipfile, load_pyproject_toml
+
+if TYPE_CHECKING:
+    from tomlkit.items import AoT, Table
 
 
 @dataclass
@@ -65,6 +69,7 @@ class PipenvUvMigration:
         self._migrate_dev_dependencies()
         self._migrate_scripts()
         self._migrate_source()
+        self._cleanup()
         self._save()
 
     def _migrate_dependencies(self) -> None:
@@ -175,6 +180,21 @@ class PipenvUvMigration:
             if set_explicit:
                 source.add("explicit", True)  # noqa: FBT003
             self._tool_uv_index.append(source)
+
+    def _cleanup(self) -> None:
+        # remove empty dependency-groups
+        if len(self._dependency_groups_dev) < 1:
+            self._dependency_groups.pop("dev")
+        if len(self._dependency_groups) < 1:
+            self._pyproject.pop("dependency-groups")
+        # remove empty `tool.uv.*`
+        for section in ("sources", "index"):
+            if len(self._tool_uv[section]) < 1:
+                self._tool_uv.pop(section)
+        if len(self._tool_uv) < 1:
+            self._tool.pop("uv")
+        if len(self._tool) < 1:
+            self._pyproject.pop("tool")
 
     def _save(self) -> None:
         if self._option.dry_run:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,11 @@ def pipfile() -> Path:
 
 
 @pytest.fixture
+def pipfile_single_source() -> Path:
+    return Path("tests/testdata/toml/Pipfile_single_source")
+
+
+@pytest.fixture
 def original_pyproject_toml() -> Path:
     return Path("tests/testdata/toml/pyproject.toml")
 
@@ -16,6 +21,11 @@ def original_pyproject_toml() -> Path:
 @pytest.fixture
 def expect_pyproject_toml() -> Path:
     return Path("tests/testdata/toml/expect_pyproject.toml")
+
+
+@pytest.fixture
+def expect_single_source_pyproject_toml() -> Path:
+    return Path("tests/testdata/toml/expect_single_source_pyproject.toml")
 
 
 @pytest.fixture

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -23,6 +23,11 @@ def load_fixture(request: pytest.FixtureRequest) -> Callable[[str], Any]:
             "original_pyproject_toml",
             "expect_pyproject_toml",
         ),
+        (
+            "pipfile_single_source",
+            "original_pyproject_toml",
+            "expect_single_source_pyproject_toml",
+        ),
     ],
 )
 def test_migrate(
@@ -56,6 +61,11 @@ def test_migrate(
             "pipfile",
             "original_pyproject_toml",
             "expect_pyproject_toml",
+        ),
+        (
+            "pipfile_single_source",
+            "original_pyproject_toml",
+            "expect_single_source_pyproject_toml",
         ),
     ],
 )

--- a/tests/testdata/toml/Pipfile
+++ b/tests/testdata/toml/Pipfile
@@ -1,12 +1,12 @@
 [[source]]
-url = "https://pypi.python.org/simple"
+url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
 [[source]]
-url = "https://example.com/simple"
+url = "https://download.pytorch.org/whl/cpu"
 verify_ssl = true
-name = "private"
+name = "pytorch-cpu"
 
 
 [packages]
@@ -16,6 +16,7 @@ requests = "*"
 pipenv-uv-migrate = {editable=true, git="https://github.com/yhino/pipenv-uv-migrate.git", ref="main"}
 "flask[dotenv,dev]" = {git = "https://github.com/pallets/flask.git", ref = "1.1.1"}
 numpy = "==1.24.4"
+torch = {version="*", index="pytorch-cpu"}
 
 [dev-packages]
 pytest = ">=5.2"

--- a/tests/testdata/toml/Pipfile_single_source
+++ b/tests/testdata/toml/Pipfile_single_source
@@ -1,0 +1,13 @@
+# vim: filetype=toml
+
+[[source]]
+url = "https://pypi.private.example.org/simple"
+verify_ssl = true
+name = "private-pypi"
+
+
+[packages]
+requests = "*"
+numpy = "==1.24.4"
+
+[dev-packages]

--- a/tests/testdata/toml/expect_pyproject.toml
+++ b/tests/testdata/toml/expect_pyproject.toml
@@ -14,11 +14,11 @@ dependencies = [
     "pipenv-uv-migrate",
     "flask[dev,dotenv]",
     "numpy==1.24.4",
+    "torch"
 ]
 
 [project.scripts]
 pipenv-uv-migrate-test = "pipenv_uv_migrate_test:main"
-
 
 [build-system]
 requires = ["hatchling"]
@@ -34,6 +34,9 @@ dev = [
 [tool.uv.sources]
 pipenv-uv-migrate = {git = "https://github.com/yhino/pipenv-uv-migrate.git", branch = "main"}
 flask = {git = "https://github.com/pallets/flask.git", tag = "1.1.1"}
+torch = {index = "pytorch-cpu"}
+
 [[tool.uv.index]]
-name = "private"
-url = "https://example.com/simple"
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true

--- a/tests/testdata/toml/expect_single_source_pyproject.toml
+++ b/tests/testdata/toml/expect_single_source_pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "pipenv-uv-migrate-test"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+authors = [
+    { name = "Yoshiyuki HINO", email = "yhinoz@gmail.com" }
+]
+requires-python = ">=3.9"
+dependencies = [
+    "requests",
+    "numpy==1.24.4",
+]
+
+[project.scripts]
+pipenv-uv-migrate-test = "pipenv_uv_migrate_test:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[[tool.uv.index]]
+name = "private-pypi"
+url = "https://pypi.private.example.org/simple"


### PR DESCRIPTION
Fix the following issue.

- #20 

I will take a different approach than the solution described in the Issue.
Follow the uv documentation and set `explict = true` for all indexes except pypi.
(but only if the pipfile has multiple sources set and contains pypi)

https://docs.astral.sh/uv/configuration/indexes/#pinning-a-package-to-an-index

> An index can be marked as explicit = true to prevent packages from being installed from that index unless explicitly pinned to it. 

Because,
Pipfile will often have pypi and other indexes set as source.
And it should be explicitly pinned only if you want to get packages from a specific index.