### PR TITLE
:bug: fix to avoid using typing_extensions

### DIFF
--- a/pipenv_uv_migrate/migration.py
+++ b/pipenv_uv_migrate/migration.py
@@ -5,13 +5,12 @@ import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from packaging.markers import Marker
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from tomlkit import aot, array, dumps, inline_table, key, table
-from typing_extensions import Any
 
 from pipenv_uv_migrate.loader import load_pipfile, load_pyproject_toml
 

--- a/pipenv_uv_migrate/migration.py
+++ b/pipenv_uv_migrate/migration.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from packaging.markers import Marker
 from packaging.requirements import Requirement


### PR DESCRIPTION
#43 

It was directly dependent on typing_extensions but was not included in the dependencies.
As a result, the indirect dependencies changed and it was not installed.

However, typing_extensions is not needed. This package will not depend on typing_extensions.