### PR TITLE
:construction_worker: replacement to use `python-semantic-release/publish-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Semantic Release
       id: release
-      uses: python-semantic-release/python-semantic-release@v10.5.3
+      uses: python-semantic-release/python-semantic-release@v10
       env:
         TZ: 'Asia/Tokyo'
       with:
@@ -41,7 +41,7 @@ jobs:
       if: steps.release.outputs.released == 'true'
 
     - name: Publish package distributions to GitHub Releases
-      uses: python-semantic-release/upload-to-gh-release@main
+      uses: python-semantic-release/publish-action@v10
       if: steps.release.outputs.released == 'true'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #36